### PR TITLE
Avoid resolv.conf from being overwritten

### DIFF
--- a/pia.sh
+++ b/pia.sh
@@ -195,6 +195,9 @@ fvpnreset()						# Restore all settings and exit openvpn gracefully.
 
 fdnschange()						# Change DNS servers to PIA.
 {
+	if [ $(command -v pacman) ];then
+		systemctl stop systemd-resolved.service
+	fi
 	echo "$INFO Changed DNS to PIA servers."
 	cp /etc/resolv.conf /etc/resolv.conf.bak
 	echo '''#PIA DNS Servers
@@ -212,6 +215,9 @@ fmace()						# Enable PIA MACE DNS based ad blocking.
 
 fdnsrestore()						# Revert to original DNS servers.
 {
+	if [ $(command -v pacman) ];then
+		systemctl start systemd-resolved.service
+	fi
 	echo "$INFO Restored DNS servers."
 	cp /etc/resolv.conf.bak /etc/resolv.conf
 }


### PR DESCRIPTION
On Arch Linux and Arch based OSes the system service automatically adds the router as a DNS provider, this causes your ISPs DNS to be used. Upon running with the DNS option stop the service and start it again on exit.